### PR TITLE
follow symlinks when finding openstack creds

### DIFF
--- a/openstack_creds
+++ b/openstack_creds
@@ -106,7 +106,7 @@ choose() {
 }
 
 # Discover credential files in pass
-for c in $(find $PSDIR -type f -name "*$MATCH$SUFFIX" | sort); do
+for c in $(find -L $PSDIR -type f -name "*$MATCH$SUFFIX" | sort); do
     c="${c#$PSDIR}"
     c="${c%$SUFFIX}"
     creds="$creds $c"


### PR DESCRIPTION
A user might symlink dirs (from keybasefs or dropbox) into
~/.password-store. Make `find` follow symlinks so that these dirs will
still work.