### PR TITLE
keep terminal contents intact

### DIFF
--- a/bash-functions
+++ b/bash-functions
@@ -18,7 +18,7 @@ function creds() {
 }
 
 function chcreds() {
-    rmcreds && openstack_creds "$1" && creds
+    tput smcup && tput cup 0 0 && rmcreds && openstack_creds "$1" && creds && tput rmcup
 }
 
 function rmcreds() {


### PR DESCRIPTION
use tput commands to maintain the current terminal state
when running chcreds interactively.