### PR TITLE
Fixed chchreds typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Use
 ---
 This script provides the following commands:
 
-  * `chchreds` to select and load credentials as username/password in the current environment
+  * `chcreds` to select and load credentials as username/password in the current environment
   * `creds`    to load the existing selected credentials as username/password in a new environment
-  * `chchreds_token` to select and load credentials as a token in the current environment
+  * `chcreds_token` to select and load credentials as a token in the current environment
   * `creds_token`    to load the existing selected credentials as a token in a new environment
   * `rmcreds`  to clear the current credentials from your current environment
   * `prcreds`  to print the current credentials

--- a/bash-completion
+++ b/bash-completion
@@ -1,4 +1,4 @@
-# completion for chchreds
+# completion for chcreds
 
 _chcreds () {
 	COMPREPLY=()

--- a/openstack_creds
+++ b/openstack_creds
@@ -3,7 +3,7 @@
 # To be used in combination with the functions in bash-functions file
 #
 # This script provides the following commands:
-#   * chchreds to change which credentials to load
+#   * chcreds to change which credentials to load
 #   * creds    to load the existing credentials in a new environment
 #   * rmcreds  to clear the current credentials from your current environment
 #


### PR DESCRIPTION
A quick fix to documentation which references the command `chchreds*` command multiple times, which seems to actually refer to `chcreds*`. Nothing major - bit it  confused me when I configured this project, and thought the update might help future users.