### PR TITLE
Ensure GPG pinentry can use the current tty for passphrase prompting

### DIFF
--- a/bash-functions
+++ b/bash-functions
@@ -5,7 +5,10 @@
 function chcreds() {
     local tmpfile
     tmpfile=$(mktemp)
-    if oscreds "$@" > "$tmpfile" 2>/dev/null; then
+    # Ensure GPG pinentry can use the current tty for passphrase prompting
+    # and forward diagnostics to the terminal instead of hiding them.
+    export GPG_TTY=$(tty)
+    if oscreds "$@" > "$tmpfile" 2>/dev/tty; then
         source "$tmpfile"
         rm "$tmpfile"
         echo "Credentials loaded for $OS_CRED"


### PR DESCRIPTION
I discovered that the `chcreds` shell function didn't work if my GPG key has a passphrase. I have to use `oscreds` directly to enter my passphrase, and then `chcreds` works normally.

GPT5 recommended to add this tiny change, so the passphrase dialog can work. I've tested on my side and it works fine. According to ChatGPT, it won't affect other users if they don't have passphrase on their keys.