### PR TITLE
Fix chcreds not clearing previously loaded credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-OpenStack bash creds helper
-===========================
+OpenStack shell creds helper
+============================
 This is a tool to make managing OpenStack credentials easier, to be used in
-combination with included bash functions below (and a bash completion file).
+combination with included shell function scripts (and completion files) for
+bash and fish.
 
 It is written in Go and supports the following Keystone authentication types:
 * Password (scoped and unscoped)
@@ -36,7 +37,7 @@ Demo
 
 Use
 ---
-The bash functions script in this repository provides the following commands:
+The shell function scripts in this repository provide the following commands:
 
   * `chcreds` to select and load credentials as username/password in the current environment
   * `recreds` to reload the current credential, which is useful if your token expires
@@ -55,14 +56,23 @@ decrypt and return the contents to `oscreds`.
 `oscreds` will then interpret the credentials and make subsequent API calls to
 Keystone to eventually return an OpenStack token.
 
-The bash function scripts will load the appropriate environment variable for
+The shell function scripts will load the appropriate environment variable for
 OpenStack CLI tools to work (almost) seamlessly.
 
-Optionally, you can add `${OS_CRED:+ \[$OS_CRED\]}` to your `PS1` var for printing your
-currently loaded credentials in your prompt. For example (coloured):
+Optionally, you can display your currently loaded credentials in your prompt:
+
+**Bash** — add `${OS_CRED:+ \[$OS_CRED\]}` to your `PS1` var. For example (coloured):
 
 ```
     PS1='\[\033[01;32m\]\u@\h\[\033[01;34m\] \w\[\033[01;33m\]${OS_CRED:+ \[$OS_CRED\]}\[\033[00m\] \$ '
+```
+
+**Fish** — add the following to your `fish_prompt` function:
+
+```
+    if set -q OS_CRED
+        printf ' [%s]' $OS_CRED
+    end
 ```
 
 
@@ -98,9 +108,22 @@ Once you have the `oscreds` binary, put it somewhere in your path
     cp oscreds ~/.local/bin/
 ```
 
-You'll then want to grab a copy of the `bash-functions` file from this repo
+### Bash
+
+Grab a copy of the `bash-functions` file from this repo
 and drop it into your `.bashrc.d` (or similar) or source it from your `.bashrc`
 to load automatically in your shell.
+
+### Fish
+
+Source the `fish-functions` file from your `~/.config/fish/config.fish`:
+
+``` sh
+    source /path/to/fish-functions
+```
+
+Or copy the individual functions into `~/.config/fish/functions/` as
+autoloaded `.fish` files (e.g. `~/.config/fish/functions/chcreds.fish`).
 
 Adding credentials
 ------------------
@@ -157,15 +180,26 @@ the TOTP prompt.
     export OS_TOTP_REQUIRED=true
 ```
 
-Bash completion
----------------
-A bash completion script is also included for your convenience.
+Shell completion
+----------------
+Completion scripts for both bash and fish are included.
+
+### Bash
 
 To install it for your user, the following should work:
 
 ``` sh
     mkdir -p ~/.local/share/bash-completion/completions
     cp bash-completion ~/.local/share/bash-completion/completions/chcreds
+```
+
+### Fish
+
+To install it for your user, copy the completion file to your fish completions directory:
+
+``` sh
+    mkdir -p ~/.config/fish/completions
+    cp fish-completion ~/.config/fish/completions/chcreds.fish
 ```
 
 You can then use tab completion to complete the filename of the credentials file.

--- a/bash-functions
+++ b/bash-functions
@@ -7,6 +7,7 @@ function chcreds() {
         echo "Failed to load credentials" >&2
         return 1
     fi
+    rmcreds
     source <(printf '%s\n' "$creds")
     echo "Credentials loaded for $OS_CRED"
 }

--- a/fish-completion
+++ b/fish-completion
@@ -1,0 +1,15 @@
+function __oscreds_cred_files
+    set -l prefix $PASSWORD_STORE_DIR
+    if test -z "$prefix"
+        set prefix $HOME/.password-store
+    end
+    set -l prefix (string replace -r '/$' '' $prefix)/
+
+    find $prefix -name '*.openrc.gpg' -not -path '*/.*' 2>/dev/null \
+        | string replace -r "^$prefix" '' \
+        | string replace -r '\.openrc\.gpg$' ''
+end
+
+complete -c chcreds -f -a '(__oscreds_cred_files)'
+complete -c chcreds -s d -l debug -d 'Enable debug output'
+complete -c chcreds -l shell -x -a 'bash fish' -d 'Shell type for output format'

--- a/fish-completion
+++ b/fish-completion
@@ -5,9 +5,11 @@ function __oscreds_cred_files
     end
     set -l prefix (string replace -r '/$' '' $prefix)/
 
-    find $prefix -name '*.openrc.gpg' -not -path '*/.*' 2>/dev/null \
+    find $prefix -name '*.openrc.gpg' 2>/dev/null \
         | string replace -r "^$prefix" '' \
-        | string replace -r '\.openrc\.gpg$' ''
+        | string replace -r '\.openrc\.gpg$' '' \
+        | string match -v '.*' \
+        | string match -v '*/.*'
 end
 
 complete -c chcreds -f -a '(__oscreds_cred_files)'

--- a/fish-functions
+++ b/fish-functions
@@ -1,4 +1,5 @@
 function chcreds
+    rmcreds
     oscreds --shell fish $argv | source
     if test $pipestatus[1] -ne 0
         echo "Failed to load credentials" >&2

--- a/fish-functions
+++ b/fish-functions
@@ -1,0 +1,36 @@
+function chcreds
+    oscreds --shell fish $argv | source
+    if test $pipestatus[1] -ne 0
+        echo "Failed to load credentials" >&2
+        return 1
+    end
+    echo "Credentials loaded for $OS_CRED"
+end
+
+function recred
+    chcreds $OS_CRED
+end
+
+function rmcreds
+    set -l os_vars (set --names | string match 'OS_*')
+    for v in $os_vars
+        set -eg $v
+    end
+end
+
+function prcreds
+    set -l os_vars (set --names | string match 'OS_*')
+    for v in $os_vars
+        if string match -q '*PASSWORD*' $v; or string match -q '*TOKEN*' $v; or string match -q '*SECRET*' $v
+            printf '%s=******\n' $v
+        else
+            printf '%s=%s\n' $v $$v
+        end
+    end
+end
+
+function os_creds
+    if set -q OS_CRED
+        printf ' %s' $OS_CRED
+    end
+end

--- a/main.go
+++ b/main.go
@@ -4,9 +4,12 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 )
 
 var debugMode bool
+
+var shellType string
 
 func debugf(format string, args ...interface{}) {
 	if debugMode {
@@ -16,7 +19,13 @@ func debugf(format string, args ...interface{}) {
 
 func main() {
 	debug := flag.Bool("debug", false, "Enable debug output")
+	flag.StringVar(&shellType, "shell", "bash", "Shell type for output format (bash or fish)")
 	flag.Parse()
+
+	if shellType != "bash" && shellType != "fish" {
+		fmt.Fprintf(os.Stderr, "Error: unsupported shell type %q (use bash or fish)\n", shellType)
+		os.Exit(1)
+	}
 
 	debugMode = *debug
 	DebugMode = *debug
@@ -198,26 +207,40 @@ func main() {
 	outputEnvironmentVars(credFile, selectedProject, scopedToken, creds)
 }
 
+func fishEscape(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return "'" + s + "'"
+}
+
+func outputVar(name string, value string) {
+	if shellType == "fish" {
+		fmt.Printf("set -gx %s %s\n", name, fishEscape(value))
+	} else {
+		fmt.Printf("export %s=%s\n", name, value)
+	}
+}
+
 func outputEnvironmentVars(credFile CredentialFile, project *Project, token string, creds *Credentials) {
-	fmt.Printf("export OS_CRED=%s\n", credFile.DisplayName)
-	fmt.Printf("export OS_IDENTITY_API_VERSION=3\n")
-	fmt.Printf("export OS_AUTH_URL=%s\n", creds.AuthURL)
-	fmt.Printf("export OS_PROJECT_ID=%s\n", project.ID)
-	fmt.Printf("export OS_TOKEN=%s\n", token)
-	fmt.Printf("export OS_AUTH_TYPE=token\n")
+	outputVar("OS_CRED", credFile.DisplayName)
+	outputVar("OS_IDENTITY_API_VERSION", "3")
+	outputVar("OS_AUTH_URL", creds.AuthURL)
+	outputVar("OS_PROJECT_ID", project.ID)
+	outputVar("OS_TOKEN", token)
+	outputVar("OS_AUTH_TYPE", "token")
 	if creds.Region != "" {
-		fmt.Printf("export OS_REGION_NAME=%s\n", creds.Region)
+		outputVar("OS_REGION_NAME", creds.Region)
 	}
 }
 
 func outputSystemScopeVars(credFile CredentialFile, token string, creds *Credentials) {
-	fmt.Printf("export OS_CRED=%s/system\n", credFile.DisplayName)
-	fmt.Printf("export OS_IDENTITY_API_VERSION=3\n")
-	fmt.Printf("export OS_AUTH_URL=%s\n", creds.AuthURL)
-	fmt.Printf("export OS_SYSTEM_SCOPE=%s\n", creds.SystemScope)
-	fmt.Printf("export OS_TOKEN=%s\n", token)
-	fmt.Printf("export OS_AUTH_TYPE=token\n")
+	outputVar("OS_CRED", credFile.DisplayName+"/system")
+	outputVar("OS_IDENTITY_API_VERSION", "3")
+	outputVar("OS_AUTH_URL", creds.AuthURL)
+	outputVar("OS_SYSTEM_SCOPE", creds.SystemScope)
+	outputVar("OS_TOKEN", token)
+	outputVar("OS_AUTH_TYPE", "token")
 	if creds.Region != "" {
-		fmt.Printf("export OS_REGION_NAME=%s\n", creds.Region)
+		outputVar("OS_REGION_NAME", creds.Region)
 	}
 }


### PR DESCRIPTION
This depends on https://github.com/NeCTAR-RC/openstack-bash-creds-helper/pull/8, but I could refactor it if for whatever reason that one didn't want to be merged.

I noticed pre-golang re-write that running `chcreds` to change credentials would also run `rmcreds`[^1], and this functionality was dropped post-golang re-write.

The issue this causes is that variables that don't exist in the new credential aren't dropped, therefore causing unexpected behaviour of the new credentials (i.e. the new credentials don't have permissions in the previously loaded project).

[^1]: https://github.com/NeCTAR-RC/openstack-bash-creds-helper/blob/6b8998243b2590095495a23038ee3692adf43a4f/bash-functions#L34